### PR TITLE
Bump 'vitejs/plugin-react'

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -51,7 +51,7 @@
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
-    "@vitejs/plugin-react": "^3.0.1",
+    "@vitejs/plugin-react": "^4.0.1",
     "magic-string": "^0.30.0",
     "react-docgen": "^7.0.0"
   },


### PR DESCRIPTION
This removes a deprecation warning: `WARN  deprecated tslint@6.1.3: TSLint has been deprecated in favor of ESLint (...)` causes by using an old version of aforementioned plugin (which still used `tslint`)
